### PR TITLE
Add ability to set dynamic configuration as part of a bootz operation.

### DIFF
--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -304,10 +304,24 @@ message BootConfig {
   // Proprietary key-value parameters that are required as part of boot
   // configuration (e.g., feature flags, or vendor-specific hardware knobs).
   google.protobuf.Struct metadata = 1;
+
+  // vendor_config and oc_config specify boot configuration that is considered
+  // immutable per the specification described in github.com/openconfig/bootz.
+  // 
   // Native format vendor configuration.
   bytes vendor_config = 2;
   // JSON rendered OC configuration.
   bytes oc_config = 3;
+
+  // dynamic_vendor_config and dynamic_oc_config specify boot configuration
+  // that is required at boot time, but can be overwritten by dynamic
+  // configuration such as that applied by a gnmi.Set RPC call.
+  //
+  // Native format vendor configuration.
+  bytes dynamic_vendor_config = 5;
+  // JSON rendered OC configuration.
+  bytes dynamic_oc_config = 6;
+
   // Bootloader key-value parameters that are required as part of boot
   // configuration.
   google.protobuf.Struct bootloader_config = 4;


### PR DESCRIPTION
```
commit 94b4912a79bdc53e8d9b0643183690c3d3e0b7ff
Author: Rob Shakir <robjs@google.com>
Date:   Mon May 19 13:59:51 2025 -0700

    Add dynamic configuration to a `BootConfig` message.
    
     * (M) proto/bootz.proto
       - In some cases, the configuration that needs to be applied
         through the boot process is not immutable per the current
         specification of the bootz process. This change adds the
         ability to provide dynamic configuration during an initial
         boot that may be overwritten later in the process.
```

# Change justification

Consider the scenario that a device is being boostrapped from factory-reset (zero-ised) state. In such cases, the bootz server provides a `BootConfig` which contains the minimum manageable state of the device. This may include some configuration such as ACLs that protect the control-plane of the device. Currently, such an ACL becomes immutable, which means that to change it, a client needs to know that it must also call `gnoi.bootconfig.SetBootConfig` as well as `gnmi.Set` to change some configuration of the device. This is a workable solution -- but adds some complexity to the calling client system.

An alternative design -- proposed herein -- is to allow two different types of configuration to be applied during the initial bootstrap operation:

 1. immutable (precendence 10) boot configuration -- which contains the static minimum-manageable-state configuration of the device.
 1. dynamic (precedence 100) configuration -- which contains dynamic config that is required during the initial bootstrap.

This simplifies the overall operation for configuration management, since configuration that is truly immutable boot configuration still remains within the bootz namespace, and configuration that is required at boot time but is dynamic remains within a namespace where it can be mutated.
